### PR TITLE
Update SidebarMenu.js

### DIFF
--- a/app/components/SidebarMenu/SidebarMenu.js
+++ b/app/components/SidebarMenu/SidebarMenu.js
@@ -144,17 +144,18 @@ class SidebarMenu extends React.Component {
             >
             <ul className={ sidebarMenuClass } ref={ this.containerRef }>
             {
-                React.Children.map(this.props.children, (child) =>
-                    <MenuContext.Consumer>
-                    {
-                        (ctx) => React.cloneElement(child, {
-                            ...ctx,
-                            currentUrl: this.props.location.pathname,
-                            slim: isSlim
-                        })
-                    }
-                    </MenuContext.Consumer>
-                )
+                React.Children.map(this.props.children, (child) => {
+                    return child ? 
+                        <MenuContext.Consumer>
+                          {
+                              (ctx) => React.cloneElement(child, {
+                                  ...ctx,
+                                  currentUrl: this.props.location.pathname,
+                                  slim: isSlim
+                              })
+                          }
+                      </MenuContext.Consumer> : null;                    
+                })
             }
             </ul>
             </MenuContext.Provider>


### PR DESCRIPTION
mod: skip rendering of menuItem if 'child' is null or undefined. 

Could be used for conditional adding, etc SidebarMiddleNav.js
{isShowMenuItem  ? (
        <SidebarMenu.Item
          icon={<i className="fa fa-fw fa-check-square-o"></i>}
          title="protected" to='/protected-page' exact />
      ): null }