### PR TITLE
Update faker dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ag-grid-community": "^21.0.1",
     "ag-grid-react": "^21.0.1",
     "bootstrap": "^4.3.1",
-    "faker": "^4.1.0",
+    "@faker-js/faker": "^6.0.0-alpha.7",
     "font-awesome": "^4.7.0",
     "holderjs": "^2.9.6",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Hello,

Given the fact that the faker dependency is not available anymore since a vulnerability was introduced which led to the removal of the original git repository. 
I would like to ask if you could update the dependency to the new and stable one (you can check on this link https://www.npmjs.com/package/@faker-js/faker).
Thank you!